### PR TITLE
size

### DIFF
--- a/src/constitutive/elastic/test.rs
+++ b/src/constitutive/elastic/test.rs
@@ -33,6 +33,14 @@ macro_rules! test_elastic_constitutive_model
             let first_piola_kirchoff_stress = model.calculate_first_piola_kirchoff_stress(&deformation_gradient);
             assert!((EPSILON*model.get_shear_modulus()/first_piola_kirchoff_stress[0][1] - 1.0).abs() < EPSILON)
         }
+        #[test]
+        fn size()
+        {
+            assert_eq!(
+                std::mem::size_of::<$elastic_constitutive_model>(),
+                std::mem::size_of::<crate::constitutive::ConstitutiveModelParameters>()
+            )
+        }
         crate::constitutive::elastic::test::test_elastic_constitutive_model_constructed!($elastic_constitutive_model_constructed);
     }
 }

--- a/src/constitutive/test.rs
+++ b/src/constitutive/test.rs
@@ -6,3 +6,11 @@ pub const GENTPARAMETERS: &[Scalar; 3] = &[NEOHOOKEANPARAMETERS[0], NEOHOOKEANPA
 pub const MOONEYRIVLINPARAMETERS: &[Scalar; 3] = &[NEOHOOKEANPARAMETERS[0], NEOHOOKEANPARAMETERS[1], 1.0];
 pub const NEOHOOKEANPARAMETERS: &[Scalar; 2] = &[13.0, 3.0];
 pub const YEOHPARAMETERS: &[Scalar; 6] = &[NEOHOOKEANPARAMETERS[0], NEOHOOKEANPARAMETERS[1], -1.0, 3e-1, -1e-3, 1e-5];
+
+#[test]
+fn size()
+{
+    assert_eq!(
+        std::mem::size_of::<super::ConstitutiveModelParameters>(), 16
+    )
+}

--- a/src/fem/block/element/linear/test.rs
+++ b/src/fem/block/element/linear/test.rs
@@ -226,6 +226,16 @@ macro_rules! test_linear_finite_element_with_constitutive_model
                 )
             }
         }
+        #[test]
+        fn size()
+        {
+            // really only for hyperelastic constitutive models (no state variables)
+            assert_eq!(
+                std::mem::size_of::<$element::<$constitutive_model>>(),
+                std::mem::size_of::<$constitutive_model>()
+                + std::mem::size_of::<GradientVectors<N>>()
+            )
+        }
     }
 }
 pub(crate) use test_linear_finite_element_with_constitutive_model;

--- a/src/fem/block/test.rs
+++ b/src/fem/block/test.rs
@@ -729,6 +729,16 @@ macro_rules! test_finite_element_block_with_constitutive_model
                 }
             }
         }
+        #[test]
+        fn size()
+        {
+            assert_eq!(
+                std::mem::size_of::<Block<$constitutive_model, D, E, $element::<$constitutive_model>, G, N>>(),
+                std::mem::size_of::<Connectivity<E, N>>()
+                + std::mem::size_of::<CurrentNodalCoordinates<D>>()
+                + E * std::mem::size_of::<$element::<$constitutive_model>>()
+            )
+        }
     }
 }
 pub(crate) use test_finite_element_block_with_constitutive_model;

--- a/src/math/tensor/rank_0/test.rs
+++ b/src/math/tensor/rank_0/test.rs
@@ -45,3 +45,12 @@ fn divide()
     let b: TensorRank0 = 2.0;
     assert_eq!(a / b, 0.5);
 }
+
+#[test]
+fn size()
+{
+    assert_eq!(
+        std::mem::size_of::<TensorRank0>(),
+        std::mem::size_of::<f64>()
+    )
+}

--- a/src/math/tensor/rank_1/list/test.rs
+++ b/src/math/tensor/rank_1/list/test.rs
@@ -1,6 +1,7 @@
 use super::
 {
     TensorRank0,
+    TensorRank1,
     TensorRank1List,
     TensorRank1ListTrait,
     TensorRank2,
@@ -453,6 +454,15 @@ fn new()
             assert_eq!(tensor_rank_1_entry_i, array_entry_i)
         )
     );
+}
+
+#[test]
+fn size()
+{
+    assert_eq!(
+        std::mem::size_of::<TensorRank1List::<3, 1, 8>>(),
+        std::mem::size_of::<[TensorRank1::<3, 1>; 8]>()
+    )
 }
 
 #[test]

--- a/src/math/tensor/rank_1/test.rs
+++ b/src/math/tensor/rank_1/test.rs
@@ -300,6 +300,15 @@ fn norm()
 }
 
 #[test]
+fn size()
+{
+    assert_eq!(
+        std::mem::size_of::<TensorRank1::<3, 1>>(),
+        std::mem::size_of::<[TensorRank0; 3]>()
+    )
+}
+
+#[test]
 fn sub_tensor_rank_1_to_self()
 {
     (get_tensor_rank_1() - get_tensor_rank_1_a()).iter()

--- a/src/math/tensor/rank_2/list/test.rs
+++ b/src/math/tensor/rank_2/list/test.rs
@@ -1,6 +1,7 @@
 use super::
 {
     TensorRank0,
+    TensorRank2,
     TensorRank2List,
     TensorRank2ListTrait
 };
@@ -137,6 +138,15 @@ fn new()
             )
         )
     );
+}
+
+#[test]
+fn size()
+{
+    assert_eq!(
+        std::mem::size_of::<TensorRank2List::<3, 1, 1, 8>>(),
+        std::mem::size_of::<[TensorRank2::<3, 1, 1>; 8]>()
+    )
 }
 
 #[test]

--- a/src/math/tensor/rank_2/list_2d/test.rs
+++ b/src/math/tensor/rank_2/list_2d/test.rs
@@ -220,6 +220,15 @@ fn new()
 }
 
 #[test]
+fn size()
+{
+    assert_eq!(
+        std::mem::size_of::<TensorRank2List2D::<3, 1, 1, 8>>(),
+        std::mem::size_of::<[[TensorRank2::<3, 1, 1>; 8]; 8]>()
+    )
+}
+
+#[test]
 fn zero()
 {
     TensorRank2List2D::<3, 1, 1, 8>::zero().iter()

--- a/src/math/tensor/rank_2/test.rs
+++ b/src/math/tensor/rank_2/test.rs
@@ -1334,6 +1334,15 @@ fn norm_dim_9()
 }
 
 #[test]
+fn size()
+{
+    assert_eq!(
+        std::mem::size_of::<TensorRank2::<3, 1, 1>>(),
+        std::mem::size_of::<[TensorRank1::<3, 1>; 3]>()
+    )
+}
+
+#[test]
 fn second_invariant()
 {
     assert_eq!(get_tensor_rank_2_dim_4().second_invariant(), 16.0);

--- a/src/math/tensor/rank_3/test.rs
+++ b/src/math/tensor/rank_3/test.rs
@@ -1,6 +1,7 @@
 use super::
 {
     TensorRank0,
+    TensorRank2,
     TensorRank3,
     TensorRank3Trait
 };
@@ -446,6 +447,15 @@ fn new()
             )
         )
     );
+}
+
+#[test]
+fn size()
+{
+    assert_eq!(
+        std::mem::size_of::<TensorRank3::<3, 1, 1, 1>>(),
+        std::mem::size_of::<[TensorRank2::<3, 1, 1>; 3]>()
+    )
 }
 
 #[test]

--- a/src/math/tensor/rank_4/list/test.rs
+++ b/src/math/tensor/rank_4/list/test.rs
@@ -1,6 +1,7 @@
 use super::
 {
     TensorRank0,
+    TensorRank4,
     TensorRank4List,
     TensorRank4ListTrait
 };
@@ -218,6 +219,15 @@ fn new()
             )
         )
     );
+}
+
+#[test]
+fn size()
+{
+    assert_eq!(
+        std::mem::size_of::<TensorRank4List::<3, 1, 1, 1, 1, 8>>(),
+        std::mem::size_of::<[TensorRank4::<3, 1, 1, 1, 1>; 8]>()
+    )
 }
 
 #[test]

--- a/src/math/tensor/rank_4/test.rs
+++ b/src/math/tensor/rank_4/test.rs
@@ -6,6 +6,7 @@ use super::
     super::rank_1::TensorRank1Trait,
     TensorRank2,
     TensorRank2Trait,
+    TensorRank3,
     TensorRank4,
     TensorRank4Inverse,
     TensorRank4Trait,
@@ -1118,6 +1119,15 @@ fn new()
             )
         )
     );
+}
+
+#[test]
+fn size()
+{
+    assert_eq!(
+        std::mem::size_of::<TensorRank4::<3, 1, 1, 1, 1>>(),
+        std::mem::size_of::<[TensorRank3::<3, 1, 1, 1>; 3]>()
+    )
 }
 
 #[test]

--- a/src/mechanics/test.rs
+++ b/src/mechanics/test.rs
@@ -60,3 +60,16 @@ pub fn get_translation_reference_configuration() -> ReferenceCoordinate
 {
     ReferenceCoordinate::new([4.4, 5.5, 6.6])
 }
+
+#[test]
+fn size()
+{
+    assert_eq!(
+        std::mem::size_of::<Scalar>(),
+        std::mem::size_of::<f64>()
+    );
+    assert_eq!(
+        std::mem::size_of::<DeformationGradient>(),
+        std::mem::size_of::<[[f64; 3]; 3]>()
+    );
+}


### PR DESCRIPTION
- enforce size of hyperelastic constitutive models is same as the size of a reference to an arbitrary length array of Scalars
- size enforcement actually very easy
